### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,30 +13,30 @@ Octoliner	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin 	KEYWORD2
-reset 	KEYWORD2
-pinMode 	KEYWORD2
-digitalWrite 	KEYWORD2
-analogWrite 	KEYWORD2
-analogWrite16 	KEYWORD2
-digitalRead KEYWORD2
-analogRead 	KEYWORD2
-changeAddr 	KEYWORD2
-changeAddrWithUID KEYWORD2
-saveAddr 	KEYWORD2
-pinModePort 	KEYWORD2
-digitalWritePort 	KEYWORD2
-digitalReadPort 	KEYWORD2
-pwmFreq 	KEYWORD2
-getUID 	KEYWORD2
-adcSpeed 	KEYWORD2
-adcFilter 	KEYWORD2
-setEncoderPins 	KEYWORD2
-readEncoderDiff 	KEYWORD2
-setSensitivity 	KEYWORD2
-setBrightness 	KEYWORD2
-getBinaryLine 	KEYWORD2
-mapLine 	KEYWORD2
+begin	KEYWORD2
+reset	KEYWORD2
+pinMode	KEYWORD2
+digitalWrite	KEYWORD2
+analogWrite	KEYWORD2
+analogWrite16	KEYWORD2
+digitalRead	KEYWORD2
+analogRead	KEYWORD2
+changeAddr	KEYWORD2
+changeAddrWithUID	KEYWORD2
+saveAddr	KEYWORD2
+pinModePort	KEYWORD2
+digitalWritePort	KEYWORD2
+digitalReadPort	KEYWORD2
+pwmFreq	KEYWORD2
+getUID	KEYWORD2
+adcSpeed	KEYWORD2
+adcFilter	KEYWORD2
+setEncoderPins	KEYWORD2
+readEncoderDiff	KEYWORD2
+setSensitivity	KEYWORD2
+setBrightness	KEYWORD2
+getBinaryLine	KEYWORD2
+mapLine	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords