### PR TITLE
Replace lineMap function.

### DIFF
--- a/src/Octoliner.h
+++ b/src/Octoliner.h
@@ -32,6 +32,7 @@ private:
                                 , 2
                                 , 1
                             };
+    float value;
 };
 
 #endif  // OCTOLINER_H


### PR DESCRIPTION
Предыдущая функция дает нелинейный результат по отношению к отклонению от линии из за того что линия может перекрывать как один, так и соседние несколько датчиков. Новая функция уверенно работает при толщине линии 18 - 24 мм не "разбалтывая" PID контроллер. Еще маленький трик: при потере линии датчик выдает последнее состояние, что, как правило, выводит драгстер обратно на линию.